### PR TITLE
Add Katz Backoff and mode for printing of generator information

### DIFF
--- a/markovian-cli/src/bin/markovian/generator.rs
+++ b/markovian-cli/src/bin/markovian/generator.rs
@@ -235,7 +235,7 @@ fn command_print_probabilities(cmd: &ProbabilityCommand) {
 
     for w in &cmd.words {
         let lp: f64 = generator.log_prob(w) as f64;
-        println!("{} ln(p)={} p={}", w, lp, lp.exp());
+        println!("{} log10(p)={} p={}", w, lp / (10.0f64).ln(), lp.exp());
     }
 }
 

--- a/markovian-cli/src/bin/markovian/simple.rs
+++ b/markovian-cli/src/bin/markovian/simple.rs
@@ -58,6 +58,11 @@ pub struct GenerateCommand {
     /// Bias to apply to calculated probabilities
     #[structopt(long)]
     bias: Option<f32>,
+
+    /// Katz back-off coefficient - minimum weight
+    /// to use before falling back to a shorter context
+    #[structopt(long)]
+    katz_coefficient: Option<f32>,
 }
 
 pub fn run(cmd: &Command) {
@@ -161,7 +166,14 @@ fn command_generate(cmd: &GenerateCommand) {
     }
 
     // Finally we generate some words
-    let words = generate_words(&generator, cmd.count, &cmd.prefix, &cmd.suffix).unwrap();
+    let words = generate_words(
+        &generator,
+        cmd.count,
+        &cmd.prefix,
+        &cmd.suffix,
+        cmd.katz_coefficient,
+    )
+    .unwrap();
 
     for x in words {
         println!("{}", x);

--- a/markovian-core/src/weighted_sampler.rs
+++ b/markovian-core/src/weighted_sampler.rs
@@ -11,7 +11,7 @@ where
 {
     // Why does this need to be a BTreeMap, not just Vec<(T,usize)>?
     pub counts: BTreeMap<T, D>,
-    total: D,
+    pub total: D,
 }
 
 impl<T, D> WeightedSampler<T, D>
@@ -59,11 +59,10 @@ where
     T: Ord,
     D: Field,
 {
-    pub fn logp(&self, v: &T) -> f32 {
-        match self.counts.get(v) {
-            None => -f32::INFINITY,
-            Some(v) => (v.as_f64() / self.total.as_f64()).ln() as f32,
-        }
+    pub fn logp(&self, v: &T) -> Option<f32> {
+        self.counts
+            .get(v)
+            .map(|v| (v.as_f64() / self.total.as_f64()).ln() as f32)
     }
 }
 


### PR DESCRIPTION
Also added ability to print information about a generator,
including the weight ranges for prefixes

Changes the serialisation format, since we need to store
multiple lengths of prefix.


```
> markovian generator info generator.gen
Prefix totals (Katz Coefficients)
  0 : range: 47193 -- 47193  mean: 47193  count: 1
  1 : range: 1 -- 11922  mean: 1440.6334  count: 30
  2 : range: 1 -- 7948  mean: 80.91756  count: 485
  3 : range: 1 -- 3974  mean: 11.322952  count: 3115
N-Gram weights
  1 : "range: 1 -- 11922  mean: 1573.1  count: 30"
  2 : "range: 1 -- 7948  mean: 89.11134  count: 485"
  3 : "range: 1 -- 3974  mean: 12.594686  count: 3116
```


```
markovian generator generate --katz-coefficient=5.0 ...
markovian generator probability --katz-coefficient=5.0 ...
markovian simple generate --katz-coefficient=5.0 ...
```